### PR TITLE
Implement topological sort to fix equations where variables use themeselves in their creation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,13 @@
 CC = gcc
-CFLAGS = -Wall -Wextra -std=c11 -pedantic -g -std=c11 -lm 
+CFLAGS = -Wall -Wextra -std=c11 -pedantic -g -std=c11 -lm
 SRC = src/
 IN = $(SRC)autodiff.c $(SRC)mlp.c $(SRC)main.c
 OUT = autodiff
-
 make: $(IN)
 	$(CC) $(IN) -o $(OUT) $(CFLAGS)
+
+run_demo: $(DEMO_C) $(DEMO_H)
+	$(CC) demo/demo_old.c demo/autodiff_old.c
+	./a.out
+	$(CC) demo/demo_new.c src/autodiff.c
+	./a.out

--- a/demo/autodiff_old.c
+++ b/demo/autodiff_old.c
@@ -1,0 +1,173 @@
+#include "autodiff_old.h"
+
+// For debugging purposes (such as printing the computation tree)
+// note that the order matters.
+const char* operators[] = {
+    "add ", "sub ", "mul ", "pow ", "tanh", "relu", "sigm", "nil"
+};
+
+void ad_init_tape(Tape* tp) {
+    tp->val_buf = calloc(INIT_TAPE_SIZE, sizeof(Value));
+    tp->cap = INIT_TAPE_SIZE;
+    tp->count = 1;
+}
+
+void ad_destroy_tape(Tape* tp) {
+    free(tp->val_buf);
+}
+
+size_t ad_create(Tape* tp, float value){
+    if (tp->count >= tp->cap){
+
+        tp->cap = Extend(tp->cap);
+        tp->val_buf = realloc(tp->val_buf, sizeof(Value) * tp->cap);
+        if (!tp->val_buf) {
+            fprintf(stderr, "Not enough memory, buy more ram!\n");
+            exit(1);
+        }
+    }
+
+    Value* res = tp->val_buf + tp->count;
+    res->data = value;
+    res->grad = 0.0f;
+    res->left_child = 0;
+    res->right_child = 0;
+    res->op = COUNT;
+    tp->count++;
+    return tp->count-1;
+}
+
+size_t ad_add(Tape* tp, size_t a, size_t b){
+    float data = GET(a).data + GET(b).data;
+    size_t out = ad_create(tp, data);
+    GET(out).left_child = a;
+    GET(out).right_child = b;
+    GET(out).op = ADD;
+    return out;
+}
+
+size_t ad_sub(Tape* tp, size_t a, size_t b){
+    float data = GET(a).data - GET(b).data;
+    size_t out = ad_create(tp, data);
+    GET(out).left_child = a;
+    GET(out).right_child = b;
+    GET(out).op = SUB;
+    return out;
+}
+
+size_t ad_mul(Tape* tp, size_t a, size_t b){
+    float data = GET(a).data * GET(b).data;
+    size_t out = ad_create(tp, data);
+    GET(out).left_child = a;
+    GET(out).right_child = b;
+    GET(out).op = MUL;
+    return out;
+}
+
+size_t ad_pow(Tape* tp, size_t a, size_t b){
+    float data = powf(GET(a).data, GET(b).data);
+    size_t out = ad_create(tp, data);
+    GET(out).left_child = a;
+    GET(out).right_child = b;
+    GET(out).op = POW;
+    return out;
+}
+
+size_t ad_tanh(Tape* tp, size_t a){
+    size_t out = ad_create(tp, tanh(GET(a).data));
+    GET(out).left_child = a;
+    GET(out).right_child = 0;
+    GET(out).op = TANH;
+    return out;
+}
+
+size_t ad_relu(Tape* tp, size_t a){
+    size_t out = ad_create(tp, GET(a).data > 0 ? GET(a).data : 0);
+    GET(out).left_child = a;
+    GET(out).right_child = 0;
+    GET(out).op = RELU;
+    return out;
+}
+
+float sigmoid(float x) {
+    return 1/(1 + exp(-x));
+}
+
+size_t ad_sigm(Tape* tp, size_t a){
+    size_t out = ad_create(tp, sigmoid(GET(a).data));
+    GET(out).left_child = a;
+    GET(out).right_child = 0;
+    GET(out).op = SIGM;
+    return out;
+}
+
+// We propagate a value backwards
+// by computing the local derivative of the value
+// with respect to the left and right operand children.
+void _ad_reverse(Tape* tp, size_t y){
+    Value y_deref = GET(y);
+    switch (y_deref.op){
+        case SUB: {
+            GET(y_deref.left_child).grad += y_deref.grad * 1.0f;
+            GET(y_deref.right_child).grad += y_deref.grad * -1.0f;
+        } break;
+        case ADD: {
+            GET(y_deref.left_child).grad += y_deref.grad * 1.0f;
+            GET(y_deref.right_child).grad += y_deref.grad * 1.0f;
+        } break;
+        case MUL: {
+            GET(y_deref.left_child).grad += y_deref.grad * GET(y_deref.right_child).data;
+            GET(y_deref.right_child).grad += y_deref.grad * GET(y_deref.left_child).data;
+        } break;
+        case POW: {
+            float l_data = GET(y_deref.left_child).data;
+            float r_data = GET(y_deref.right_child).data;
+            GET(y_deref.left_child).grad += y_deref.grad * r_data * powf(l_data, r_data - 1);
+            GET(y_deref.right_child).grad += y_deref.grad * log(l_data) * powf(l_data, r_data);
+        } break;
+        case TANH: {
+            GET(y_deref.left_child).grad += y_deref.grad * (1 - y_deref.data*y_deref.data);
+        } break;
+        case RELU: {
+            if (y_deref.data > 0)
+                GET(y_deref.left_child).grad += y_deref.grad * 1.0f;
+        } break;
+        case SIGM: {
+            GET(y_deref.left_child).grad += y_deref.grad * y_deref.data * (1 - y_deref.data);
+        } break;
+        default: break;
+    }
+
+    // We recurse to propagate the gradients to the left and right child of the value
+    if (y_deref.left_child != 0) _ad_reverse(tp, y_deref.left_child);
+    if (y_deref.right_child != 0) _ad_reverse(tp, y_deref.right_child);
+}
+
+void ad_reverse(Tape* tp, size_t y){
+    // Initial gradient is always 1
+    // because the derivative of x w.r.t. x = 1
+    GET(y).grad = 1.0;
+    _ad_reverse(tp, y);
+}
+
+void _ad_print_tree(Tape* tp, size_t y, size_t indent){
+    if (y == 0) return;
+    Value y_deref = GET(y);
+    for (size_t i = 0; i < indent; ++i) printf(" ");
+    printf("[%s] node (data: %g, grad: %g)\n", operators[y_deref.op], y_deref.data, y_deref.grad);
+    _ad_print_tree(tp, y_deref.left_child, indent+4);
+    _ad_print_tree(tp, y_deref.right_child, indent+4);
+}
+
+void ad_print_tree(Tape* tp, size_t y){
+    printf("------------- Computation graph -------------\n");
+    _ad_print_tree(tp, y, 0);
+    printf("--------------------------------------------\n");
+}
+
+void ad_print_tape(Tape* tp){
+    for (size_t i = 0; i < tp->count; ++i){
+        printf("val: %2g, index: %3zu, left: %3zu, right: %3zu, op: %s\n",
+            tp->val_buf[i].data, i, tp->val_buf[i].left_child, tp->val_buf[i].right_child, operators[tp->val_buf[i].op]);
+    }
+}

--- a/demo/autodiff_old.h
+++ b/demo/autodiff_old.h
@@ -1,0 +1,79 @@
+#ifndef _AUTODIFF_OLD_H
+#define _AUTODIFF_OLD_H
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <stdbool.h>
+
+// Macro for extending dynamic array
+#define Extend(n) (n == 0 ? 8 : (n*2))
+
+// Current set of operators
+// Adding more operators implies adding the corresponding functions
+typedef enum {
+    ADD,
+    SUB,
+    MUL,
+    POW,
+    TANH,
+    RELU,
+    SIGM,
+    COUNT,
+} OpType;
+
+// Value struct behaving like a node in a graph
+// It is aware of its operator type and has a
+// reference to its operands in an array linked list
+typedef struct {
+    float data;
+    float grad;
+    OpType op;
+    size_t left_child;
+    size_t right_child;
+} Value;
+
+// The tape struct is a dynamic array of values
+// which function as an array linked list
+typedef struct {
+    Value* val_buf;
+    size_t count;
+    size_t cap;
+} Tape;
+
+// Most params of the tape are Tape pointers 'tp'
+// which leads to the usefulness of this macro
+#define GET(v) tp->val_buf[(v)]
+
+// The initial tape size.
+// recommended to be a multiple of 2
+#define INIT_TAPE_SIZE 8
+
+// Gradient tape functions
+void ad_init_tape(Tape* tape);
+void ad_destroy_tape(Tape* tape);
+void ad_print_tape(Tape* tp);
+
+// Create a differentiable value
+// that gets added to the provided tape
+size_t ad_create(Tape* tp, float value);
+
+// autodiff API for common operations
+// note that the operands are 'size_t' and serve as array pointers for the tape
+size_t ad_add(Tape* tp, size_t a, size_t b);
+size_t ad_sub(Tape* tp, size_t a, size_t b);
+size_t ad_mul(Tape* tp, size_t a, size_t b);
+size_t ad_pow(Tape* tp, size_t a, size_t b);
+
+// Common activation functions
+size_t ad_tanh(Tape* tp, size_t a);
+size_t ad_relu(Tape* tp, size_t a);
+size_t ad_sigm(Tape* tp, size_t a);
+
+// Compute gradients of value in reverse mode
+void ad_reverse(Tape* tp, size_t y);
+
+// Print computation tree
+void ad_print_tree(Tape* tp, size_t y);
+
+#endif //_AUTODIFF_H

--- a/demo/demo_new.c
+++ b/demo/demo_new.c
@@ -1,0 +1,29 @@
+#include "../src/autodiff.h"
+
+void do_demo(float a_val) {
+    Tape tape = {0};
+    Tape *tp = &tape;
+    ad_init_tape(tp);
+    size_t a = ad_create(tp, a_val);
+    size_t b = ad_create(tp, 10);
+    size_t c = ad_add(tp, a, b);
+    c = ad_add(tp, c, ad_add(tp, c, a));
+    ad_reverse(tp, c);
+    printf("a: data: %f | grad: %f\n", GET(a).data, GET(a).grad);
+    printf("b: data: %f | grad: %f\n", GET(b).data, GET(b).grad);
+    printf("c: data: %f | grad: %f\n", GET(c).data, GET(c).grad);
+}
+
+int main() {
+    printf("--------------\n");
+    printf("Now with the new implementation\n");
+    printf("--------------\n");
+    float a_val = 5;
+    do_demo(a_val);
+    printf("--------------\n");
+    printf("The gradient of a is now 3\n");
+    printf("Which is correct, after increasing the value of\n");
+    printf("a from 5->6 the value of c goes from 35->38\n");
+    printf("--------------\n");
+    do_demo(a_val + 1);
+}

--- a/demo/demo_old.c
+++ b/demo/demo_old.c
@@ -1,0 +1,26 @@
+#include "./autodiff_old.h"
+
+void do_demo(float a_val) {
+    Tape tape = {0};
+    Tape *tp = &tape;
+    ad_init_tape(tp);
+    size_t a = ad_create(tp, a_val);
+    size_t b = ad_create(tp, 10);
+    size_t c = ad_add(tp, a, b);
+    c = ad_add(tp, c, ad_add(tp, c, a));
+    ad_reverse(tp, c);
+    printf("a: data: %f | grad: %f\n", GET(a).data, GET(a).grad);
+    printf("b: data: %f | grad: %f\n", GET(b).data, GET(b).grad);
+    printf("c: data: %f | grad: %f\n", GET(c).data, GET(c).grad);
+}
+
+int main() {
+    float a_val = 5;
+    do_demo(a_val);
+    printf("--------------\n");
+    printf("But the gradient of a is not 4\n");
+    printf("When I increase a from 5 -> 6 the value of\n");
+    printf("c increases by 3, so the grad of a is 3\n");
+    printf("--------------\n");
+    do_demo(a_val + 1);
+}

--- a/src/autodiff.h
+++ b/src/autodiff.h
@@ -23,7 +23,7 @@ typedef enum {
 } OpType;
 
 // Value struct behaving like a node in a graph
-// It is aware of its operator type and has a 
+// It is aware of its operator type and has a
 // reference to its operands in an array linked list
 typedef struct {
     float data;
@@ -31,6 +31,7 @@ typedef struct {
     OpType op;
     size_t left_child;
     size_t right_child;
+    size_t visited;
 } Value;
 
 // The tape struct is a dynamic array of values
@@ -42,14 +43,14 @@ typedef struct {
 } Tape;
 
 // Most params of the tape are Tape pointers 'tp'
-// which leads to the usefulness of this macro 
+// which leads to the usefulness of this macro
 #define GET(v) tp->val_buf[(v)]
 
 // The initial tape size.
 // recommended to be a multiple of 2
 #define INIT_TAPE_SIZE 8
 
-// Gradient tape functions 
+// Gradient tape functions
 void ad_init_tape(Tape* tape);
 void ad_destroy_tape(Tape* tape);
 void ad_print_tape(Tape* tp);
@@ -77,4 +78,3 @@ void ad_reverse(Tape* tp, size_t y);
 void ad_print_tree(Tape* tp, size_t y);
 
 #endif //_AUTODIFF_H
-


### PR DESCRIPTION
To see a demonstration of the types of equations I am talking about run the *make run_demo* command.

I found that in doing equations like:
``` C
    size_t a = ad_create(tp, 5);
    size_t b = ad_create(tp, 10);
    size_t c = ad_add(tp, a, b);
    c = ad_add(tp, c, ad_add(tp, c, a));
    ad_reverse(tp, c);
```

The gradient was wrong due to reversing a variable too many times. I added a visited variable to the Value and a topological sort to avoid this and now the gradient is correct.